### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         node-version: [20.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'


### PR DESCRIPTION
## Why

CI is failing on dependency PRs (e.g. #84) with:

> The actions `actions/checkout@...` and `actions/setup-node@v6` are not allowed in with-ours/hospital-search because all actions must be pinned to a full-length commit SHA.

The org now enforces SHA-pinning for all GitHub Actions. Our `ci.yml` used version tags (`@v6`), so any workflow run fails at `Set up job`.

## What

Pin both actions to full-length commit SHAs at the intended versions, with version comments so Dependabot keeps updating them:

- `actions/checkout` → `v7.0.0` (`9c091bb…`) — also picks up the bump in #84
- `actions/setup-node` → `v6.4.0` (`48b55a0…`)

Supersedes #84.